### PR TITLE
Add setup to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 simple boilerplate for building REST API using Hapi
 
-## Commands
-```cp .env.example .env```
+## Setup
+`cp .env.example .env`
 
 ## Commands
 ```sh

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 simple boilerplate for building REST API using Hapi
 
 ## Commands
+```cp .env.example .env```
+
+## Commands
 ```sh
 # Development mod
 npm run dev

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 simple boilerplate for building REST API using Hapi
 
 ## Setup
-`cp .env.example .env`
+```sh
+# Copy env
+cp .env.example .env
+
+# Install dependencies
+npm install
+```
 
 ## Commands
 ```sh


### PR DESCRIPTION
It took me a short bit to realize I was missing `.env`. I updated the readme to add setup. I'm hoping this helps other who might pull this repo down in the future.

```
[1] "keychain" must not be a sparse array
    at Object.exports.process (/Users/tbrobston/Developer/hapi-starter/node_modules/joi/lib/errors.js:196:19)
    at internals.Object._validateWithOptions (/Users/tbrobston/Developer/hapi-starter/node_modules/joi/lib/types/any/index.js:675:31)
    at module.exports.internals.Any.root.validate (/Users/tbrobston/Developer/hapi-starter/node_modules/joi/lib/index.js:138:23)
    at module.exports.internals.Any.root.attempt (/Users/tbrobston/Developer/hapi-starter/node_modules/joi/lib/index.js:167:29)
    at module.exports.internals.Any.root.assert (/Users/tbrobston/Developer/hapi-starter/node_modules/joi/lib/index.js:162:14)
    at Object.internals.implementation [as hapi-now-auth] (/Users/tbrobston/Developer/hapi-starter/node_modules/@now-ims/hapi-now-auth/lib/index.js:59:9)
    at module.exports.internals.Auth._strategy (/Users/tbrobston/Developer/hapi-starter/node_modules/hapi/lib/auth.js:52:47)
    at Object.register (/Users/tbrobston/Developer/hapi-starter/plugins/auth.js:7:17)
    at internals.Server.register (/Users/tbrobston/Developer/hapi-starter/node_modules/hapi/lib/server.js:434:35)
    at <anonymous>
  isJoi: true,
  name: 'ValidationError',
  details: 
   [ { message: '"keychain" must not be a sparse array',
       path: [Array],
       type: 'array.sparse',
       context: [Object] } ],
  _object: 
   { accessTokenName: 'authorization',
     allowQueryToken: false,
     allowCookieToken: false,
     allowMultipleHeaders: false,
     allowChaining: false,
     tokenType: 'Bearer',
     verifyJWT: true,
     keychain: [ undefined ],
     verifyOptions: { algorithms: [Array], ignoreExpiration: false },
     unauthorized: [Function: unauthorized],
     validate: [AsyncFunction: validate] },
  annotate: [Function] }
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: sh
Arguments: -c node .
Directory: /Users/tbrobston/Developer/hapi-starter
Output:
".
```